### PR TITLE
Reduce mutation invocations and increase reliability 

### DIFF
--- a/src/common/common.js
+++ b/src/common/common.js
@@ -1,14 +1,88 @@
-/**
- * Removes all links to the discover page
- */
-export function hideDiscoverLinks() {
-  // Remove direct links to the discover page
-  document
-      .querySelectorAll('a[href="/discover"]')
-      .forEach((elem) => elem.parentElement.removeChild(elem));
+import {
+  MutationObserver,
+} from '../util/util';
 
-  // Replace links to the home page to the stream page
-  document
-      .querySelectorAll('[href="/"]')
-      .forEach((elem) => elem.setAttribute('href', '/stream'));
+/**
+ * The ElementWatcher class is used to ensure a given element
+ * exists on the page and react to when it is found or changed.
+ */
+class ElementWatcher {
+  /**
+   * Initialises a new instance of the ElementWatcher class.
+   * A MutationObserver instance is used to determine
+   * when the desired element has been added to the DOM.
+   * @param {String} selector
+   * @param {*} callbacks
+   */
+  constructor(selector, callbacks) {
+    this.onchange = callbacks.onchange;
+    this.onfound = callbacks.onfound;
+
+    const options = {
+      childList: true,
+      subtree: true,
+    };
+
+    const body = document.querySelector('body');
+
+    // Watch for changes to the body element. When we can locate the stream
+    // list element within the body stop this observer
+    const finder = new MutationObserver(() => {
+      const list = body.querySelector(selector);
+      if (!list) {
+        return;
+      }
+
+      const elem = list;
+      finder.disconnect();
+      if (this.onfound) {
+        this.onfound(elem);
+      }
+
+      // Once we've found the activity feed, set up a new observer
+      // that will be invoked whenever elements within the activity feed
+      // change.
+      const elemWatcher = new MutationObserver(() => {
+        if (this.onchange) {
+          this.onchange(elem);
+        }
+      });
+
+      elemWatcher.observe(list, options);
+    });
+
+    finder.observe(body, options);
+  }
 }
+
+/**
+ * The ActivityFeed class represents the activity feed on the stream
+ * page of SoundCloud.
+ */
+export class ActivityFeed extends ElementWatcher {
+  /**
+   * Initialises a new instance of the ActivityFeed class
+   * @param {*} callbacks
+   */
+  constructor(callbacks) {
+    const selector = '.stream__list';
+    super(selector, callbacks);
+  }
+}
+
+/**
+ * The PageHeader class represents the page header at the top of
+ * the SoundCloud page
+ */
+export class PageHeader extends ElementWatcher {
+  /**
+   * Initialises a new instance of the PageHeader class
+   * @param {*} callbacks
+   */
+  constructor(callbacks) {
+    const selector = '.header__left';
+    super(selector, callbacks);
+  }
+}
+
+

--- a/src/header/header.js
+++ b/src/header/header.js
@@ -1,0 +1,20 @@
+import {PageHeader} from '../common/common.js';
+
+/**
+ * Removes all links to the discover page
+ */
+export function hideDiscoverLinks() {
+  new PageHeader({
+    onfound(elem) {
+      // Remove direct links to the discover page
+      elem
+          .querySelectorAll('a[href="/discover"]')
+          .forEach((elem) => elem.parentElement.removeChild(elem));
+
+      // Replace links to the home page to the stream page
+      elem
+          .querySelectorAll('[href="/"]')
+          .forEach((elem) => elem.setAttribute('href', '/stream'));
+    },
+  });
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,15 @@
 import {removeReposts} from './stream/stream.js';
-import {hideDiscoverLinks} from './common/common.js';
+import {hideDiscoverLinks} from './header/header.js';
 import {onPath, redirect} from './util/util.js';
+import {Log} from './log/log.js';
 
 // Paths
 const PATH_STREAM = '/stream';
 const PATH_HOME = '/';
 const PATH_DISCOVER = '/discover';
 const PATH_ANY = '*';
+
+Log.info('Initialising...');
 
 // Invoke functions on specific paths
 onPath(PATH_STREAM, removeReposts);

--- a/src/log/log.js
+++ b/src/log/log.js
@@ -1,0 +1,49 @@
+/**
+ * The Logger class is used to provide a uniform logger throughout
+ * the extension
+ */
+class Logger {
+  /**
+   * Write an info level message to the console
+   * @param {String} msg
+   */
+  info(msg) {
+    log(console.info, msg);
+  }
+
+  /**
+   * Write an debug level message to the console
+   * @param {String} msg
+   */
+  debug(msg) {
+    log(console.debug, msg);
+  }
+
+  /**
+   * Write an error level message to the console
+   * @param {String} msg
+   */
+  error(msg) {
+    log(console.error, msg);
+  }
+
+  /**
+   * Write an warning level message to the console
+   * @param {String} msg
+   */
+  warn(msg) {
+    log(console.warn, msg);
+  }
+}
+
+export const Log = new Logger();
+
+/**
+ * Writes a log to the console, the 'fn' parameter expects a function
+ * that can be invoked to write a log.
+ * @param {Function} fn
+ * @param {String} msg
+ */
+function log(fn, msg) {
+  fn(`[SES] ${msg}`);
+}

--- a/src/stream/stream.js
+++ b/src/stream/stream.js
@@ -1,10 +1,5 @@
-import {
-  MutationObserver,
-} from '../util/util';
-
-const CLASS_REPOST = '.soundContext__repost';
-const CLASS_LIST_ITEM = '.soundList__item';
-const CLASS_STREAM_LIST = '.stream__list';
+import {ActivityFeed} from '../common/common.js';
+import {Log} from '../log/log.js';
 
 /**
  * Locates all elements in the document with a class matching CLASS_REPOST.
@@ -14,30 +9,24 @@ const CLASS_STREAM_LIST = '.stream__list';
  * CLASS_STREAM_LIST.
  */
 export function removeReposts() {
-  const list = document.querySelector(CLASS_STREAM_LIST);
-  if (!list) {
-    return;
-  }
+  new ActivityFeed({
+    onchange(elem) {
+      const repostSelector = '.soundContext__repost';
+      const listItemSelector = '.soundList__item';
+      const reposts = elem.querySelectorAll(repostSelector);
 
-  const mutationObserver = new MutationObserver(() => {
-    const reposts = document.querySelectorAll(CLASS_REPOST);
+      if (!reposts || !reposts.length) {
+        return;
+      }
 
-    if (!reposts) {
-      return;
-    }
+      reposts.forEach((rp) => {
+        const item = rp.closest(listItemSelector);
 
-    reposts.forEach((rp) => {
-      const item = rp.closest(CLASS_LIST_ITEM);
+        item.parentNode.removeChild(item);
+      });
 
-      item.parentNode.removeChild(item);
-    });
+      Log.info(`Removed ${reposts.length} reposted items`);
+    },
   });
-
-  const options = {
-    childList: true,
-    subtree: true,
-  };
-
-  mutationObserver.observe(list, options);
 }
 

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -18,16 +18,21 @@ export function onPath(expected, cb) {
       actual = actual.slice(0, -1);
     }
 
-    if (expected === '*' || expected === actual && actual !== lastPath) {
+    // If the path has actually changed and matches the expected path, invoke
+    // the callback.
+    if (actual !== lastPath && (expected === '*' || expected === actual)) {
       cb();
     }
 
     lastPath = actual;
   });
 
-  const body = document.querySelector('body');
+  // Elements within <head> change when we switch path. This was
+  // chosen to minimise the amount of times we'll invoke the
+  // MutationObserver.
+  const head = document.querySelector('head');
   const config = {childList: true, subtree: true};
-  observer.observe(body, config);
+  observer.observe(head, config);
 }
 
 /**


### PR DESCRIPTION
* Created `class ActivityFeed` that uses a `MutationObserver` to know when the expected DOM element actually exists. Once it's got it, the observer is disconnected and a new observer instance checks for changes in that element to invoke a registered `onChange` handler.

* Reworked `onPath` to check for changes in the `<head>` tag rather than the entire document/body. This should minimise the number of invocations and help performance a bit

* Reworked `hideDiscoverLinks` to look for items within the header, rather than the whole document. This still seems to be a bit unreliable sometimes